### PR TITLE
Partial charge converter

### DIFF
--- a/pymatgen/io/openmm/tests/test_utils.py
+++ b/pymatgen/io/openmm/tests/test_utils.py
@@ -3,6 +3,7 @@ import parmed
 import pytest
 import openff.toolkit.topology
 import pymatgen
+from pymatgen.analysis.graphs import MoleculeGraph
 import openmm
 from openff.toolkit.typing.engines import smirnoff
 
@@ -29,6 +30,7 @@ from pymatgen.io.openmm.utils import (
     smiles_to_atom_type_array,
     smiles_to_resname_array,
     xyz_to_molecule,
+    molgraph_to_openff_mol,
 )
 
 from pymatgen.io.openmm.tests.datafiles import (
@@ -373,3 +375,21 @@ def test_water_models(modela, modelb):
     force_b = system_b.getForces()[0].getBondParameters(0)
     # assert rOH is different for two different water models
     assert force_a[2] != force_b[2]
+
+
+def test_molgraph_to_openff_mol():
+    """transform a water MoleculeGraph to a OpenFF water molecule"""
+    pf6 = pymatgen.core.Molecule.from_file(PF6_xyz)
+    pf6_graph = MoleculeGraph.with_edges(
+        pf6,
+        {
+            (0, 1): {"weight": 1},
+            (0, 2): {"weight": 1},
+            (0, 3): {"weight": 1},
+            (0, 4): {"weight": 1},
+            (0, 5): {"weight": 1},
+            (0, 6): {"weight": 1},
+        },
+    )
+    molgraph_to_openff_mol(pf6_graph)
+    return

--- a/pymatgen/io/openmm/tests/test_utils.py
+++ b/pymatgen/io/openmm/tests/test_utils.py
@@ -31,6 +31,7 @@ from pymatgen.io.openmm.utils import (
     smiles_to_resname_array,
     xyz_to_molecule,
     molgraph_to_openff_mol,
+    openff_mol_to_molgraph,
 )
 
 from pymatgen.io.openmm.tests.datafiles import (
@@ -379,9 +380,9 @@ def test_water_models(modela, modelb):
 
 def test_molgraph_to_openff_mol():
     """transform a water MoleculeGraph to a OpenFF water molecule"""
-    pf6 = pymatgen.core.Molecule.from_file(PF6_xyz)
+    pf6_mol = pymatgen.core.Molecule.from_file(PF6_xyz)
     pf6_graph = MoleculeGraph.with_edges(
-        pf6,
+        pf6_mol,
         {
             (0, 1): {"weight": 1},
             (0, 2): {"weight": 1},
@@ -392,4 +393,14 @@ def test_molgraph_to_openff_mol():
         },
     )
     molgraph_to_openff_mol(pf6_graph)
+    # TODO: add real test
+    return
+
+
+def test_openff_mol_to_molgraph():
+    """transform a water MoleculeGraph to a OpenFF water molecule"""
+    pf6_openff = openff.toolkit.topology.Molecule.from_smiles("F[P-](F)(F)(F)(F)F")
+    openff_mol_to_molgraph(pf6_openff)
+
+    # TODO: add real test
     return

--- a/pymatgen/io/openmm/tests/test_utils.py
+++ b/pymatgen/io/openmm/tests/test_utils.py
@@ -397,8 +397,6 @@ def test_molgraph_to_openff_mol():
     pf6_graph2 = openff_mol_to_molgraph(pf6_openff)
     pf6_openff2 = molgraph_to_openff_mol(pf6_graph2)
     assert pf6_openff == pf6_openff2
-    # TODO: add real test
-    return
 
 
 def test_openff_mol_to_molgraph():

--- a/pymatgen/io/openmm/tests/test_utils.py
+++ b/pymatgen/io/openmm/tests/test_utils.py
@@ -402,16 +402,19 @@ def test_molgraph_to_openff_mol():
 
 
 def test_openff_mol_to_molgraph():
-    """transform a water MoleculeGraph to a OpenFF water molecule"""
+    import networkx as nx
+    import networkx.algorithms.isomorphism as iso
+
     pf6_openff = openff.toolkit.topology.Molecule.from_smiles("F[P-](F)(F)(F)(F)F")
     pf6_charges = np.load(PF6_charges)[[1, 0, 2, 3, 4, 5, 6]]
     pf6_openff.partial_charges = pf6_charges * elementary_charge
     pf6_graph = openff_mol_to_molgraph(pf6_openff)
     assert len(pf6_graph.molecule) == 7
     assert pf6_graph.molecule.charge == -1
-
+    em = iso.categorical_edge_match("weight", 1)
+    nm = iso.numerical_node_match(["formal_charge", "partial_charge"], [0, 0])
     pf6_openff2 = molgraph_to_openff_mol(pf6_graph)
-    assert pf6_openff.to_smiles() == pf6_openff2.to_smiles()
+    pf6_graph2 = openff_mol_to_molgraph(pf6_openff2)
+    assert nx.is_isomorphic(pf6_graph.graph, pf6_graph2.graph, edge_match=em, node_match=nm)
+    assert pf6_graph.molecule == pf6_graph2.molecule
     assert pf6_openff == pf6_openff2
-    # TODO: add real test
-    return

--- a/pymatgen/io/openmm/utils.py
+++ b/pymatgen/io/openmm/utils.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import warnings
 import tempfile
 
+import networkx as nx
 import numpy as np
 from openbabel import pybel
 import parmed
@@ -606,11 +607,25 @@ def parameterize_system(
     return system
 
 
-def molgraph_to_openff_mol():
+def molgraph_to_openff_mol(molgraph):
+    openff_mol = openff.toolkit.topology.Molecule()
+    for atom in molgraph.graph.nodes:
+        charge = atom.get("charge") or 0
+        number = atom.get("specie") or 0
+        return charge, number
+    for i, j, data in molgraph.graph.edges(data=True):
+        bond_order = data.get("weight", 1)
+        openff_mol = openff.toolkit.topology.Molecule()
+        return bond_order, openff_mol
+    return openff_mol
+
     # TODO: write molgraph_to_openff_mol function
     return
 
 
 def openff_mol_to_molgraph():
+    # store charges in node attributes
+
+    nx.set_node_attributes()
     # TODO: write openff_mol_to_molgraph function
     return

--- a/pymatgen/io/openmm/utils.py
+++ b/pymatgen/io/openmm/utils.py
@@ -609,15 +609,20 @@ def parameterize_system(
     return system
 
 
-def molgraph_to_openff_mol(molgraph):
+def molgraph_to_openff_mol(molgraph: MoleculeGraph) -> openff.toolkit.topology.Molecule:
     """
-    TODO: document this!
+    Convert a Pymatgen MoleculeGraph to an OpenFF Molecule.
+
+    If partial charges, formal charges, and aromaticity are present in site properties
+    they will be mapped onto atoms.
+    If bond order and bond aromaticity are present in edge weights and edge properties
+    they will be mapped onto bonds.
 
     Args:
-        molgraph:
+        openff_mol: OpenFF Molecule
 
     Returns:
-
+        MoleculeGraph
     """
     # create empty openff_mol and prepa
     p_table = {str(el): el.Z for el in Element}
@@ -663,15 +668,18 @@ def molgraph_to_openff_mol(molgraph):
     return openff_mol
 
 
-def openff_mol_to_molgraph(openff_mol):
+def openff_mol_to_molgraph(openff_mol: openff.toolkit.topology.Molecule) -> MoleculeGraph:
     """
-    # TODO: document this!
+    Convert an OpenFF Molecule to a Pymatgen MoleculeGraph.
+
+    Preserves partial charges, formal charges, and aromaticity in site properties.
+    Preserves bond order in edge weights and bond aromaticity in edge properties.
 
     Args:
-        openff_mol:
+        openff_mol: OpenFF Molecule
 
     Returns:
-
+        MoleculeGraph
     """
     # set up coords and species
     p_table = {el.Z: str(el) for el in Element}
@@ -697,11 +705,6 @@ def openff_mol_to_molgraph(openff_mol):
             mol[i].properties["partial_charge"] /= elementary_charge
 
         mol[i].properties["is_aromatic"] = atom.is_aromatic
-
-        mol[i].properties["partial_charge"] = atom.partial_charge
-        if isinstance(atom.partial_charge, openmm.unit.Quantity):
-            mol[i].properties["partial_charge"] /= elementary_charge
-        # TODO: quantity?
 
     # create molgraph and set graph attributes
     molgraph = MoleculeGraph.with_empty_graph(

--- a/pymatgen/io/openmm/utils.py
+++ b/pymatgen/io/openmm/utils.py
@@ -241,6 +241,8 @@ def infer_openff_mol(
     Infer an OpenFF molecule from xyz coordinates.
     """
     with tempfile.NamedTemporaryFile() as f:
+        # TODO: allow for Molecule graphs
+        # TODO: build a MoleculeGraph -> OpenFF mol direct converter
         # these next 4 lines are cursed
         pybel_mol = BabelMolAdaptor(mol_geometry).pybel_mol  # pymatgen Molecule
         pybel_mol.write("mol2", filename=f.name, overwrite=True)  # pybel Molecule
@@ -372,6 +374,7 @@ def assign_charges_to_mols(
     Returns:
        List of charged openff Molecules
     """
+    # TODO: allow for Molecule graphs in partial charges, (or just pass in PC directly?)
     # loop through partial charges to add to force field
     matched_mols = set()
     inferred_mols = set()

--- a/pymatgen/io/openmm/utils.py
+++ b/pymatgen/io/openmm/utils.py
@@ -651,7 +651,6 @@ def molgraph_to_openff_mol(molgraph):
     partial_charge_array = np.array(partial_charges)
     if np.all(partial_charge_array == 0.0):
         partial_charge_array[0] = molgraph.molecule.charge
-    openff_mol.partial_charges = partial_charge_array * elementary_charge
 
     # set edge properties, default to single bond and assume not aromatic
     for i, j, bond_data in molgraph.graph.edges(data=True):
@@ -660,6 +659,7 @@ def molgraph_to_openff_mol(molgraph):
         openff_mol.add_bond(i, j, bond_order, is_aromatic=is_aromatic)
 
     openff_mol.add_conformer(molgraph.molecule.cart_coords * angstrom)
+    openff_mol.partial_charges = partial_charge_array * elementary_charge
     return openff_mol
 
 

--- a/pymatgen/io/openmm/utils.py
+++ b/pymatgen/io/openmm/utils.py
@@ -604,3 +604,13 @@ def parameterize_system(
     if return_charged_mols:
         return system, charged_mols
     return system
+
+
+def molgraph_to_openff_mol():
+    # TODO: write molgraph_to_openff_mol function
+    return
+
+
+def openff_mol_to_molgraph():
+    # TODO: write openff_mol_to_molgraph function
+    return

--- a/pymatgen/io/openmm/utils.py
+++ b/pymatgen/io/openmm/utils.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import warnings
 import tempfile
 
-import networkx as nx
 import numpy as np
 from openbabel import pybel
 import parmed
@@ -665,16 +664,11 @@ def openff_mol_to_molgraph(openff_mol):
     molgraph = MoleculeGraph.with_empty_graph(molecule=mol, name=openff_mol.name)
     molgraph.set_node_attributes()
     # store charges in node attributes
-    for i, bond in enumerate(openff_mol.bonds):
+    for bond in openff_mol.bonds:
         molgraph.graph.add_edge(
             bond.atom1_index,
             bond.atom2_index,
             weight=bond.bond_order,
             edge_properties={"is_aromatic": bond.is_aromatic},
         )
-        return
-    for bond in openff_mol.bonds:
-        bond
-    nx.set_node_attributes()
-    # TODO: write openff_mol_to_molgraph function
-    return
+    return molgraph

--- a/pymatgen/io/openmm/utils.py
+++ b/pymatgen/io/openmm/utils.py
@@ -627,7 +627,6 @@ def molgraph_to_openff_mol(molgraph: MoleculeGraph) -> openff.toolkit.topology.M
     # create empty openff_mol and prepa
     p_table = {str(el): el.Z for el in Element}
     openff_mol = openff.toolkit.topology.Molecule()
-    # TODO: assert all charged or all not charged?
 
     # set atom properties
     partial_charges = []


### PR DESCRIPTION
Implement interoperability between MoleculeGraph and OpenFF mol. Move more internal representations to MoleculeGraph. Allow partial charge assignment with MoleculeGraph.

TODOs:
- [x] create functions to convert between MoleculeGraph and OpenFF Molecule
- [ ] Allow partial charge assignment function to take MoleculeGraph in addition to Molecule, PDB, and XYZ
- [ ] Move internal representations that are currently Molecule to MoleculeGraph